### PR TITLE
Add metadata & frontmatter

### DIFF
--- a/resource.abnf
+++ b/resource.abnf
@@ -3,7 +3,12 @@
 ; These are all separated from each other by LF or CRLF line endings.
 ; Except for empty lines, all lines start with a non-whitespace character.
 resource = line *(newline line)
-line = section-head / entry / comment / empty-line
+line = frontmatter / section-head / entry / metadata / comment / empty-line
+
+; Comments and metadata before the frontmatter attach to the entire resource.
+; A valid resource must have at most one frontmatter,
+; and it must not have any section-head or entry lines before the frontmatter.
+frontmatter = "---"
 
 ; As in TOML, entries after a section-head belong to the section.
 ; Sections do not nest under preceding sections,
@@ -11,11 +16,17 @@ line = section-head / entry / comment / empty-line
 section-head = "[" [ws] id [ws] "]" [ws]
 entry = id [ws] "=" [ws] value
 
+; Metadata attaches properties to the subsequent frontmatter, section-head or entry.
+; Other metadata lines are valid between metadata and its target,
+; but comments and empty lines are not.
+; As with entries, the value of metadata may span multiple lines,
+; provided that each beyond the first is indented by some whitespace.
+metadata = "@" id-part [ws value]
+
 ; Adjacent comments should be considered as a single multi-line comment.
-; Comments attach to a subsequent section-head or entry,
+; Comments attach to a subsequent frontmatter, section-head or entry,
 ; if not separated from it by any empty lines.
-; A first comment in a resource preceding any section-head or entry
-; and followed by an empty line attaches to the whole resource.
+; Metadata lines are valid between comments and their target.
 comment = "#" *(content / backslash)
 empty-line = [ws]
 
@@ -24,9 +35,13 @@ newline = CRLF / LF
 
 ; An identifier is made up of one or more non-empty parts separated by dots.
 ; Common symbols and non-printable characters must be \escaped in identifiers.
-id = id-part *([ws] "." [ws] id-part)
-id-part = 1*(id-char / id-escape)
-id-char = ALPHA / DIGIT / "-" / "_"
+; To avoid conflicts with frontmatter, and id starting with `---`
+; or consisting only of `-` characters must `\-` escape at least one of them.
+id = id-start [id-part] *([ws] "." [ws] id-part)
+id-start = id-safe / ("-" id-safe) / ("-" "-" id-safe)
+id-part = 1*(id-char / "-")
+id-char = id-safe / id-escpe
+id-safe = ALPHA / DIGIT / "_"
         / %x00A1-1FFF / %x200C-200D / %x2030-205E / %x2070-2FEF
         / %x3001-D7FF / %xF900-FDCF / %xFDF0-FFFD / %x10000-EFFFF
 id-escape = backslash (escaped / symbols)


### PR DESCRIPTION
Closes #14 
CC @zbraniecki and @flodolo, if you've any comments

This adds syntax for `@` prefixed key-value metadata, and for `---` as a separator between resource-level comments & metadata (aka the "frontmatter") and the resource body. Together, they look like this (using `ini` highlighting, which mostly works):

```ini
@locale en-US
---

one = A message with no properties

@version 3
@since 2023-11-30
two = A message with some properties

# Freeform comments must come before properties
@param $foobar - An input argument
                 with a multiline value
three = Some {$foobar} message

# Metadata also attaches to section-heads
@deprecated
[section]

four = Foo
```

Like comments, metadata attaches to the "next thing" in the syntax. To allow for resource-level attachment, a `---` frontmatter separator is included in the syntax. This allows using the same syntax and concepts for resources as for sections and entries. As detailed in #14, it's also a common pattern used in other formats. While many other formats with frontmatter do not themselves have something like `@metadata` and so need to pick a separately defined format for their frontmatter content (often YAML), e.g. YAML itself uses `%directives` in its frontmatter.

Metadata values use the same `value` construct as message entries, which means that they may be multiline if indented, and their inner syntax (beyond the keyword) will need to be defined separately. The `@` prefix is rather intentionally chosen to allow matching Javadoc/JSDoc/TSDoc syntax, which is relatively well known.

It's likely that not all consumers of a resource will care about all or any of the metadata. For example, while something like `@version` could be important to a system tracking which messages need re-translation, it probably would not have any effect during the message's formatting. On the other hand, a resource-level `@locale` could end up significant for all consumers.

At this level, the syntax does not differentiate between metadata fields depending on e.g. their relevance to formatting; that should be done separately. One purely mechanical way to allow for some formatting-relevant metadata would be to only support that for the frontmatter. Another alternative would be to introduce another sigil beyond the `@` to differentiate such. Or we could define an explicit list of keywords with a formatting impact.

Comments or empty lines are not allowed between metadata lines and the line they're attaching to. This is intentional, and meant to ensure that they stay together.

The `id` rule needs to get narrowed a bit as a part of this change, as it can't start with `---`.