### PR TITLE
Add data model as TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ A resource may classify its messages into groupings,
 and it may include additional data or metadata relating to them.
 It should be possible to represent a resource in a text-based human-friendly manner.
 
+### How to Contribute
+
+- **Issues** are for specific aspects of the resulting specification.
+  Discussions here should be focused, and stay on topic.
+  New issues must include a sufficient initial description to introduce themselves,
+  and may contain an exploration of possible solutions to them.
+- **Pull requests** help develop and define the eventual specification.
+  Accepting and merging a PR should not be taken as the final word on any topic,
+  but each change should be an improvement on the previous.
+  Each PR should only apply one change that may be squashed to the `main` branch.
+  Text content should use [semantic line breaks](https://sembr.org/).
+  A PR may close one or more issues, but this is not required.
+- **Discussions** are freeform, and may well refer to multiple issues or topics.
+  This is also the forum in which we should develop further our ways of working,
+  which may also include interactions and forums outside this repository,
+  such as occasional video calls.
+
+We welcome your participation and interest!
+
+## Syntax
+
 As currently specified, a message resource looks like this (syntax highlighting only approximate):
 
 ```ini
@@ -48,21 +69,18 @@ The exact syntax for properties and
 is defined separately.
 The canonical definition of the resource syntax is found in [`resource.abnf`](./resource.abnf).
 
-### How to Contribute
+## Data Model
 
-- **Issues** are for specific aspects of the resulting specification.
-  Discussions here should be focused, and stay on topic.
-  New issues must include a sufficient initial description to introduce themselves,
-  and may contain an exploration of possible solutions to them.
-- **Pull requests** help develop and define the eventual specification.
-  Accepting and merging a PR should not be taken as the final word on any topic,
-  but each change should be an improvement on the previous.
-  Each PR should only apply one change that may be squashed to the `main` branch.
-  Text content should use [semantic line breaks](https://sembr.org/).
-  A PR may close one or more issues, but this is not required.
-- **Discussions** are freeform, and may well refer to multiple issues or topics.
-  This is also the forum in which we should develop further our ways of working,
-  which may also include interactions and forums outside this repository,
-  such as occasional video calls.
+A message resource data model corresponding to the syntax definition
+is included as [`resource.d.ts`](./resource.d.ts),
+an extensively commented TypeScript definition.
 
-We welcome your participation and interest!
+To enable interchange, a JSON Schema definition of the data model
+is also provided in [`resource.json`](./resource.json).
+This corresponds to `Resource<string, Message, false>`
+in the parametric TypeScript definition,
+where `Message` is a [MessageFormat 2 Message](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/README.md#messages).
+
+As with the MessageFormat 2 data model,
+the message resource JSON Schema relaxes some aspects of the data model,
+allowing comment and metadata values to be optional rather than required properties.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ an extensively commented TypeScript definition.
 
 To enable interchange, a JSON Schema definition of the data model
 is also provided in [`resource.json`](./resource.json).
-This corresponds to `Resource<string, Message, false>`
+This corresponds to `Resource<Message, false>`
 in the parametric TypeScript definition,
 where `Message` is a [MessageFormat 2 Message](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/README.md#messages).
 

--- a/resource.d.ts
+++ b/resource.d.ts
@@ -1,0 +1,189 @@
+/**
+ * The data model representation of a message resource.
+ *
+ * This interface is generic, to allow for metadata and entry values
+ * to be represented by their parsed representations,
+ * and for invalid resources to be represented.
+ *
+ * This is not a CST, so does not encode whitespace or empty lines.
+ * Users are encouraged to not consider them significant,
+ * and to always normalize the syntax representation of a resource
+ * when manipulating it programmatically.
+ *
+ * Similarly, all character escapes are processed in this representation
+ * (for all identifiers, and for `string` metadata and entry values),
+ * and users are encouraged to always normalize
+ * the syntax representation of escaped characters.
+ *
+ * @typeParam M - Metadata value type
+ * @typeParam V - Entry value type
+ * @typeParam J - If `true`, the resource body may include Junk
+ */
+export interface Resource<M = string, V = string, J extends boolean = false> {
+  /**
+   * A comment on the whole resource, which applies to all of its entries.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   * 
+   * An empty or whitespace-only comment will be represented by an empty string.
+   *
+   * In the syntax, resource comments are separated from the rest of the resource
+   * by a frontmatter separator line `---`.
+   */
+  comment: string;
+
+  /**
+   * Metadata attached to the whole resource.
+   *
+   * In the syntax, these are separated from the rest of the resource
+   * by a frontmatter separator line `---`.
+   */
+  meta: Metadata<M>[];
+
+  /**
+   * The body of a resource, consisting of an array of
+   * - section headers
+   * - message entries
+   * - comments
+   * - optionally, any junk content that could not be parsed.
+   *
+   * Each of the above may be identified by its string `type` property.
+   *
+   * Empty lines are not included in the body.
+   *
+   * A valid resource may have an empty body.
+   */
+  body: Line<M, V, J>[];
+}
+
+export type Line<M = string, V = string, J extends boolean = false> =
+  | SectionHead<M>
+  | Entry<M, V>
+  | Comment
+  | (J extends true ? Junk : never);
+
+/**
+ * Metadata is attached to a resource, section, or a single entry.
+ */
+export interface Metadata<M = string> {
+  /**
+   * A non-empty string keyword.
+   *
+   * Most likely a sequence of `a-z` characters,
+   * but may technically contain _any_ characters
+   * which might require escaping in the syntax.
+   */
+  key: string;
+
+  /**
+   * The metadata contents.
+   * If this is a `string`,
+   */
+  value: M;
+}
+
+export interface SectionHead<M = string> {
+  type: "section";
+
+  /**
+   * A comment on the whole section, which applies to all of its entries.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   * 
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+
+  /** Metadata attached to this section. */
+  meta: Metadata<M>[];
+
+  /**
+   * The section identifier.
+   *
+   * Each `string` part of the identifier MUST be a non-empty string.
+   * 
+   * The resource syntax requires this array to be non-empty,
+   * but empty identifier arrays MAY be used
+   * when this data model is used to represent other message resource formats,
+   * such as Fluent FTL files.
+   *
+   * The identifiers of entries following a section header are not normalized,
+   * i.e. they do not include this identifier.
+   */
+  id: string[];
+}
+
+export interface Entry<M = string, V = string> {
+  type: "entry";
+
+  /**
+   * A comment on this entry.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   * 
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+
+  /** Metadata attached to this entry. */
+  meta: Metadata<M>[];
+
+  /**
+   * The entry identifier.
+   *
+   * This MUST be a non-empty array of non-empty `string` values.
+   *
+   * The identifiers of entries following a section header are not normalized,
+   * i.e. they do not include its identifier.
+   *
+   * In a valid resource, each entry has a distinct normalized identifier,
+   * i.e. the concatenation of its section header identifier (if any) and its own.
+   */
+  id: string[];
+
+  /**
+   * The value of an entry, i.e. the message.
+   * 
+   * String values have all their character \escapes processed.
+   * Note that the processed values of `\\`, `\{`, `\|`, and `\}`
+   * are exactly the same characters sequences.
+   */
+  value: V;
+}
+
+export interface Comment {
+  type: "comment";
+
+  /**
+   * A standalone comment.
+   *
+   * May contain multiple lines separated by `\n` characters.
+   * For each line, the `#` sigil and up to one space or tab is trimmed
+   * from the start of the line, along with any trailing whitespace.
+   * In the syntax, each line will be prefixed by `#` and if the line is not empty, one space.
+   * 
+   * An empty or whitespace-only comment will be represented by an empty string.
+   * */
+  comment: string;
+}
+
+export interface Junk {
+  type: "junk";
+
+  /**
+   * Raw source contents from an invalid resource.
+   * 
+   * If junk is included in the parsed representation of a resource,
+   * it represents content that failed to parse.
+   */
+  source: string;
+}

--- a/resource.d.ts
+++ b/resource.d.ts
@@ -80,7 +80,10 @@ export interface Metadata<M = string> {
 
   /**
    * The metadata contents.
-   * If this is a `string`,
+   *
+   * String values have all their character \escapes processed.
+   * Note that the processed values of `\\`, `\{`, `\|`, and `\}`
+   * are exactly the same characters sequences.
    */
   value: M;
 }

--- a/resource.d.ts
+++ b/resource.d.ts
@@ -1,7 +1,7 @@
 /**
  * The data model representation of a message resource.
  *
- * This interface is generic, to allow for metadata and entry values
+ * This interface is generic, to allow for entry values
  * to be represented by their parsed representations,
  * and for invalid resources to be represented.
  *
@@ -11,15 +11,14 @@
  * when manipulating it programmatically.
  *
  * Similarly, all character escapes are processed in this representation
- * (for all identifiers, and for `string` metadata and entry values),
+ * (for all identifiers, metadata, and for `string` entry values),
  * and users are encouraged to always normalize
  * the syntax representation of escaped characters.
  *
- * @typeParam M - Metadata value type
  * @typeParam V - Entry value type
  * @typeParam J - If `true`, the resource body may include Junk
  */
-export interface Resource<M = string, V = string, J extends boolean = false> {
+export interface Resource<V = string, J extends boolean = false> {
   /**
    * A comment on the whole resource, which applies to all of its sections and entries.
    *
@@ -41,20 +40,20 @@ export interface Resource<M = string, V = string, J extends boolean = false> {
    * In the syntax, these are separated from the rest of the resource
    * by a frontmatter separator line `---`.
    */
-  meta: Metadata<M>[];
+  meta: Metadata[];
 
   /**
    * The body of a resource, consisting of an array of sections.
    *
    * A valid resource may have an empty sections array.
    */
-  sections: Section<M, V, J>[];
+  sections: Section<V, J>[];
 }
 
 /**
  * Metadata is attached to a resource, section, or a single entry.
  */
-export interface Metadata<M = string> {
+export interface Metadata {
   /**
    * A non-empty string keyword.
    *
@@ -67,14 +66,14 @@ export interface Metadata<M = string> {
   /**
    * The metadata contents.
    *
-   * String values have all their character \escapes processed.
+   * Values have all their character \escapes processed.
    * Note that the processed values of `\\`, `\{`, `\|`, and `\}`
    * are exactly the same characters sequences.
    */
-  value: M;
+  value: string;
 }
 
-export interface Section<M = string, V = string, J extends boolean = false> {
+export interface Section<V = string, J extends boolean = false> {
   /**
    * A comment on the whole section, which applies to all of its entries.
    *
@@ -88,7 +87,7 @@ export interface Section<M = string, V = string, J extends boolean = false> {
   comment: string;
 
   /** Metadata attached to this section. */
-  meta: Metadata<M>[];
+  meta: Metadata[];
 
   /**
    * The section identifier.
@@ -117,10 +116,10 @@ export interface Section<M = string, V = string, J extends boolean = false> {
    *
    * Empty lines are not included in the data model.
    */
-  entries: (Entry<M, V> | Comment | (J extends true ? Junk : never))[];
+  entries: (Entry<V> | Comment | (J extends true ? Junk : never))[];
 }
 
-export interface Entry<M = string, V = string> {
+export interface Entry<V = string> {
   type: "entry";
 
   /**
@@ -136,7 +135,7 @@ export interface Entry<M = string, V = string> {
   comment: string;
 
   /** Metadata attached to this entry. */
-  meta: Metadata<M>[];
+  meta: Metadata[];
 
   /**
    * The entry identifier.

--- a/resource.json
+++ b/resource.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/eemeli/message-resource-wg/blob/main/resource.json",
+
+  "type": "object",
+  "properties": {
+    "comment": { "type": "string" },
+    "meta": { "$ref": "#/$defs/meta" },
+    "body": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/comment" },
+          { "$ref": "#/$defs/entry" },
+          { "$ref": "#/$defs/sectionhead" }
+        ]
+      }
+    }
+  },
+  "required": ["body"],
+
+  "$defs": {
+    "comment": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "comment" },
+        "comment": { "type": "string" }
+      },
+      "required": ["type", "comment"]
+    },
+    "entry": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "entry" },
+        "comment": { "type": "string" },
+        "id": { "$ref": "#/$defs/id" },
+        "meta": { "$ref": "#/$defs/meta" },
+        "value": {
+          "$ref": "https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json"
+        }
+      },
+      "required": ["type", "id", "value"]
+    },
+    "id": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "meta": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "$ref": "#/$defs/id" },
+          "value": { "type": "string" }
+        },
+        "required": ["id", "value"]
+      }
+    },
+    "sectionhead": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "entry" },
+        "comment": { "type": "string" },
+        "id": { "$ref": "#/$defs/id" },
+        "meta": { "$ref": "#/$defs/meta" }
+      },
+      "required": ["type", "id"]
+    }
+  }
+}

--- a/resource.json
+++ b/resource.json
@@ -6,18 +6,29 @@
   "properties": {
     "comment": { "type": "string" },
     "meta": { "$ref": "#/$defs/meta" },
-    "body": {
+    "sections": {
       "type": "array",
       "items": {
-        "oneOf": [
-          { "$ref": "#/$defs/comment" },
-          { "$ref": "#/$defs/entry" },
-          { "$ref": "#/$defs/sectionhead" }
-        ]
+        "type": "object",
+        "properties": {
+          "comment": { "type": "string" },
+          "id": { "$ref": "#/$defs/id" },
+          "meta": { "$ref": "#/$defs/meta" },
+          "entries": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                { "$ref": "#/$defs/comment" },
+                { "$ref": "#/$defs/entry" }
+              ]
+            }
+          }
+        },
+        "required": ["entries"]
       }
     }
   },
-  "required": ["body"],
+  "required": ["sections"],
 
   "$defs": {
     "comment": {
@@ -55,16 +66,6 @@
         },
         "required": ["id", "value"]
       }
-    },
-    "sectionhead": {
-      "type": "object",
-      "properties": {
-        "type": { "const": "entry" },
-        "comment": { "type": "string" },
-        "id": { "$ref": "#/$defs/id" },
-        "meta": { "$ref": "#/$defs/meta" }
-      },
-      "required": ["type", "id"]
     }
   }
 }


### PR DESCRIPTION
This builds on #15, so includes the metadata as described there.

Much like the MF2 message data model, the proposed canonical resource data model is rather close to the syntactical source, but leaves out unimportant details like empty lines and other ignored whitespace. Source positions are not included, and the data model makes no attempt at being a CST representation of a parsed source.

It's expressed as TypeScript, as that allows for sufficient flexibility and expressibility. Synonymous definitions could be included later in other formats, though that might require narrowing the parametric types to some specifics.

A `Junk` definition is included, to allow for the representation of resources with invalid contents. The top-level `Resource` definition includes a type parameter that acts as a toggle for this, as there are likely to be cases where any parse error would invalidate the whole resource, and hence a representation of the resource might never include any junk.

The data model is also parametric on the metadata and message definitions. While both default to `string`, it's possible to use this same data model with further specifications of each, e.g. using the MF2 `Message` [data model](https://github.com/unicode-org/message-format-wg/tree/main/spec/data-model).

Some specific relaxations of syntax requirements are included to allow for `Resource` to represent resources using different syntaxes, such as Fluent FTL. As with the MF2 data model, we may want to ensure that this data model can losslessly represent many if not all localization resource formats.